### PR TITLE
Updating build.sbt and plugins.sbt for Play 2.2.0 and sbt-idea 1.5.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ parallelExecution in Test := false
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "1.9.1" % "test",
   "net.databinder.dispatch" %% "dispatch-core" % "0.9.5",
-  "play" %% "play-json" % "2.2-SNAPSHOT"
+  "com.typesafe.play" %% "play-json" % "2.2.0"
 )
 
 seq(lsSettings :_*)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,4 +5,4 @@ resolvers ++= Seq(
 
 addSbtPlugin("me.lessis" % "ls-sbt" % "0.1.2")
 
-addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.3.0")
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")


### PR DESCRIPTION
Hi there !

Play 2.2.0 is out and it's impossible to use AnormCypher 0.4.2 with it because of a version suffix conflict for scala-stm. Basically, it's because of play-json 2.2-SNAPSHOT which transitively depends on scala-stm 2.10.0. The stable version depends on scala-stm 2.10.

I just fixed the build.sbt to use play-json 2.2.0. I also updated sbt-idea to 1.5.1 because i got problems to download the old version (i don't remember, 1.3 or something).

If you are on this pull request because you have the same problem, a way is to remove org.anormcypher, org.scala-stm, and play directories from directory playframework/repository/cache. After that, clone AnormCypher and run "sbt publish-local" on the project. Copy and paste the anormcypher generated jar and ivy files (probably somewhere in your ~/.ivy directory, SBT outputs the exact path) to your Play repository. Update your project and it should be ok.

Thanks in advance :)
