### PR TITLE
Added Async Support.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "org.anormcypher"
 
 publishTo := Some(Resolver.sftp("AnormCypher repo", "repo.anormcypher.org", "/home/wfreeman/www/repo.anormcypher.org"))
 
-scalaVersion := "2.11.0"
+scalaVersion := "2.11.6"
 
 scalacOptions ++= Seq("-encoding", "UTF-8", "-deprecation", "-unchecked", "-feature")
 
@@ -17,9 +17,10 @@ resolvers += "Typesafe Releases" at "http://repo.typesafe.com/typesafe/releases/
 parallelExecution in Test := false
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "2.1.5" % "test",
+  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "net.databinder.dispatch" %% "dispatch-core" % "0.11.1",
-  "com.typesafe.play" %% "play-json" % "2.3.5"
+  "com.typesafe.play" %% "play-json" % "2.3.5",
+  "org.scala-lang.modules" %% "scala-async" % "0.9.2"
 )
 
 seq(lsSettings :_*)

--- a/src/test/scala/org/anormcypher/async/AnormCypherTest.scala
+++ b/src/test/scala/org/anormcypher/async/AnormCypherTest.scala
@@ -1,0 +1,185 @@
+package org.anormcypher.async
+
+import org.anormcypher._
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class AnormCypherAsyncSpec extends FlatSpec with Matchers with BeforeAndAfterEach with ScalaFutures {
+  implicit val connection = Neo4jREST(scala.util.Properties.envOrElse("NEO4J_SERVER", "localhost"))
+
+  override def beforeEach() = {
+    // initialize some test data
+    Cypher("""create 
+      (us {type:"Country", name:"United States", code:"USA", tag:"anormcyphertest"}),
+      (germany {type:"Country", name:"Germany", code:"DEU", population:81726000, tag:"anormcyphertest"}),
+      (france {type:"Country", name:"France", code:"FRA", tag:"anormcyphertest", indepYear:1789}),
+      (monaco {name:"Monaco", population:32000, type:"Country", code:"MCO", tag:"anormcyphertest"}),
+      (english {type:"Language", name:"English", code:"EN", tag:"anormcyphertest"}),
+      (french {type:"Language", name:"French", code:"FR", tag:"anormcyphertest"}),
+      (german {type:"Language", name:"German", code:"DE", tag:"anormcyphertest"}),
+      (arabic {type:"Language", name:"Arabic", code:"AR", tag:"anormcyphertest"}),
+      (italian {type:"Language", name:"Italian", code:"IT", tag:"anormcyphertest"}),
+      (russian {type:"Language", name:"Russian", code:"RU", tag:"anormcyphertest"}),
+      france-[:speaks {official:true}]->french,
+      france-[:speaks]->arabic,
+      france-[:speaks]->italian,
+      germany-[:speaks {official:true}]->german,
+      germany-[:speaks]->english,
+      germany-[:speaks]->russian,
+      (proptest {name:"proptest", tag:"anormcyphertest", f:1.234, i:1234, l:12345678910, s:"s", arri:[1,2,3,4], arrs:["a","b","c"], arrf:[1.234,2.345,3.456]});
+      """).async().futureValue
+  }
+
+  override def afterEach() = {
+    // delete the test data
+    Cypher("""match (n)
+      where n.tag = "anormcyphertest"
+      optional match n-[r]-()
+      delete n, r;
+      """).async().futureValue
+  }
+
+  "Cypher" should "be able to build a CypherStatement with apply" in {
+    val query = """
+      START n=node(*) 
+      RETURN n;
+      """
+    Cypher(query) should equal (CypherStatement(query))
+  } 
+
+  it should "be able to make a query without parameters" in {
+    val query = """
+      START n=node(*) 
+      RETURN n;
+      """
+    CypherStatement(query)()
+  }
+
+  it should "be able to build a CypherStatement and send it with apply" in {
+    val query = """
+      START n=node(*) 
+      where n.name = 'proptest'
+      RETURN n;
+      """
+    Cypher(query).async().futureValue.size should equal (1)
+  }
+
+  it should "be able to add parameters with .on()" in {
+    val query = """
+      start n=node({id}) 
+      where n.name = {test} 
+      return n;
+      """
+    Cypher(query).on("id"->0, "test"->"hello") should equal (
+      CypherStatement(query, Map("id"->0, "test"->"hello")))
+  }
+
+  it should "be able to send a query and map the results to a list" in {
+    val allCountries = Cypher("""
+      start n=node(*) 
+      where n.type = "Country"
+      and n.tag = "anormcyphertest"
+      return n.code as code, n.name as name 
+      order by name desc;
+      """)
+    val countries = allCountries.async().futureValue.map(row =>
+      row[String]("code") -> row[String]("name")
+    ).toList
+    countries should equal (
+      List("USA" -> "United States",
+           "MCO" -> "Monaco",
+           "DEU" -> "Germany",
+           "FRA" -> "France")
+    )
+  }
+
+  it should "be able to submit a few requests in a row" in {
+    val query = """
+      START n=node(*) 
+      where n.tag = "anormcyphertest"
+      RETURN n;
+      """
+    val test = Cypher(query).async().futureValue
+    Cypher(query).async().futureValue should equal (test)
+    Cypher(query).async().futureValue should equal (test)
+    Cypher(query).async().futureValue should equal (test)
+    Cypher(query).async().futureValue should equal (test)
+  }
+
+  it should "be able to extract properties of different types" in {
+    val allProps = Cypher("""
+      start n=node(*) 
+      where n.name = "proptest"
+      return n.i, n.l, n.s, n.f, n.arri, n.arrs, n.arrf;
+      """)
+    val props = allProps.async().futureValue.map(row =>
+      List(
+        row[Int]("n.i"), 
+        row[Long]("n.l"),
+        row[String]("n.s"),
+        row[Double]("n.f"),
+        row[Seq[Int]]("n.arri"),
+        row[Seq[Long]]("n.arri"),
+        row[Seq[String]]("n.arrs"),
+        row[Seq[Double]]("n.arrf")
+      )
+    ).toList.head
+    props should equal (
+      List(
+        1234, 
+        12345678910l, 
+        "s", 
+        1.234,
+        Vector(1,2,3,4), 
+        Vector(1,2,3,4), 
+        Vector("a","b","c"), 
+        Vector(1.234, 2.345, 3.456))
+    )
+  }
+
+  it should "be able to .execute() a good query" in {
+    val query = """
+      START n=node(*) 
+      RETURN n;
+      """
+    Cypher(query).executeAsync().futureValue should equal (true)
+  }
+
+  it should "be able to .execute() a bad query" in {
+    val query = """
+      START n=node(0) asdf 
+      RETURN n;
+      """
+    Cypher(query).executeAsync().futureValue  should equal (false)
+  }
+
+  it should "be able to parse nullable fields of various types" in {
+    val query = """
+      START n=node(*)
+      WHERE n.type = 'Country'
+      RETURN n.indepYear as indepYear
+      order by n.indepYear
+      """
+    val results = Cypher(query).async().futureValue.map {
+      row => row[Option[Int]]("indepYear")
+    }.toList
+    results should equal (List(Some(1789),None, None, None))
+  }
+
+  it should "fail on null fields if they're not Option" in {
+    val query = """
+      START n=node(*)
+      WHERE n.type = 'Country'
+      RETURN n.indepYear as indepYear;
+      """
+    intercept[RuntimeException] {
+      Cypher(query).async().futureValue.map {
+        row => row[Int]("indepYear")
+      }
+    }
+  }
+
+}

--- a/src/test/scala/org/anormcypher/async/AnormCypherTest.scala
+++ b/src/test/scala/org/anormcypher/async/AnormCypherTest.scala
@@ -8,6 +8,8 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class AnormCypherAsyncSpec extends FlatSpec with Matchers with BeforeAndAfterEach with ScalaFutures {
+  import org.scalatest.time._
+  implicit override val patienceConfig = PatienceConfig(timeout = Span(2, Minutes))
   implicit val connection = Neo4jREST(scala.util.Properties.envOrElse("NEO4J_SERVER", "localhost"))
 
   override def beforeEach() = {
@@ -30,7 +32,7 @@ class AnormCypherAsyncSpec extends FlatSpec with Matchers with BeforeAndAfterEac
       germany-[:speaks]->english,
       germany-[:speaks]->russian,
       (proptest {name:"proptest", tag:"anormcyphertest", f:1.234, i:1234, l:12345678910, s:"s", arri:[1,2,3,4], arrs:["a","b","c"], arrf:[1.234,2.345,3.456]});
-      """).async().futureValue
+      """).apply()
   }
 
   override def afterEach() = {
@@ -39,7 +41,7 @@ class AnormCypherAsyncSpec extends FlatSpec with Matchers with BeforeAndAfterEac
       where n.tag = "anormcyphertest"
       optional match n-[r]-()
       delete n, r;
-      """).async().futureValue
+      """).apply()
   }
 
   "Cypher" should "be able to build a CypherStatement with apply" in {

--- a/src/test/scala/org/anormcypher/async/CypherParserTest.scala
+++ b/src/test/scala/org/anormcypher/async/CypherParserTest.scala
@@ -1,0 +1,86 @@
+package org.anormcypher.async
+
+import org.anormcypher.CypherParser._
+import org.anormcypher._
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class CypherParserAsyncSpec extends FlatSpec with Matchers with BeforeAndAfterEach with ScalaFutures {
+  implicit val connection = Neo4jREST(scala.util.Properties.envOrElse("NEO4J_SERVER", "localhost"))
+
+  override def beforeEach() {
+    // initialize some test data
+    Cypher("""create 
+      (us {type:"Country", name:"United States", code:"USA", tag:"anormcyphertest"}),
+      (germany {type:"Country", name:"Germany", code:"DEU", population:81726000, tag:"anormcyphertest"}),
+      (france {type:"Country", name:"France", code:"FRA", tag:"anormcyphertest", indepYear:1789}),
+      (monaco {name:"Monaco", population:32000, type:"Country", code:"MCO", tag:"anormcyphertest"}),
+      (english {type:"Language", name:"English", code:"EN", tag:"anormcyphertest"}),
+      (french {type:"Language", name:"French", code:"FR", tag:"anormcyphertest"}),
+      (german {type:"Language", name:"German", code:"DE", tag:"anormcyphertest"}),
+      (arabic {type:"Language", name:"Arabic", code:"AR", tag:"anormcyphertest"}),
+      (italian {type:"Language", name:"Italian", code:"IT", tag:"anormcyphertest"}),
+      (russian {type:"Language", name:"Russian", code:"RU", tag:"anormcyphertest"}),
+      france-[:speaks {official:true}]->french,
+      france-[:speaks]->arabic,
+      france-[:speaks]->italian,
+      germany-[:speaks {official:true}]->german,
+      germany-[:speaks]->english,
+      germany-[:speaks]->russian,
+      (proptest {name:"proptest", tag:"anormcyphertest", f:1.234, i:1234, l:12345678910, s:"s", arri:[1,2,3,4], arrs:["a","b","c"], arrf:[1.234,2.345,3.456]});
+      """).async().futureValue
+  }
+
+  override def afterEach() {
+    // delete the test data
+    Cypher("""match (n)     
+      where n.tag = "anormcyphertest"
+      optional match (n)-[r]-()
+      delete n, r;
+      """).async().futureValue
+  }
+
+  "CypherParser" should "be able to parse a node" in {
+    case class Country(name:String, node:NeoNode)
+    val results = Cypher("start n=node(*) where n.type = 'Country' return n.name as name, n order by name desc").async().futureValue.map {
+      row => Country(row[String]("name"), row[NeoNode]("n"))
+    }.toList
+    results.head.name should equal ("United States")
+    results.head.node.props should equal (Map("name" -> "United States", "type" -> "Country", "tag" -> "anormcyphertest", "code" -> "USA"))
+  }
+
+  it should "be able to parse into a single Long" in {
+    val count: Long = Cypher("""
+      start n=node(*) 
+      where n.tag = 'anormcyphertest' 
+      return count(n)""").asAsync(scalar[Long].single).futureValue
+    count should equal (11)
+  }
+
+  it should "be able to parse a case class with a node" in {
+    val results = Cypher("start n=node(*) where n.type = 'Country' return n.name as name, n").async().futureValue.map {
+      case CypherRow(name: String, n: NeoNode) => name -> n
+      case e:Any => {//println(e);
+      }
+    }.toList
+    // TODO this isn't working!
+    //results.head("United States").props should equal (Map("name" -> "United States", "type" -> "Country", "tag" -> "anormcyphertest", "code" -> "USA"))
+  }
+
+  it should "be able to parse and flatten into a tuple" in {
+    val result:List[(String,Int)] = 
+      Cypher("""
+        start n=node(*) 
+        where n.type = 'Country' and has(n.name) and has(n.population) 
+        return n.name, n.population 
+        order by n.name
+        """
+      ).asAsync(
+        (str("n.name") ~ int("n.population")).map(flatten).*
+      ).futureValue
+    result should equal (List(("Germany",81726000), ("Monaco", 32000)))
+  }
+}

--- a/src/test/scala/org/anormcypher/async/CypherParserTest.scala
+++ b/src/test/scala/org/anormcypher/async/CypherParserTest.scala
@@ -9,6 +9,8 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class CypherParserAsyncSpec extends FlatSpec with Matchers with BeforeAndAfterEach with ScalaFutures {
+  import org.scalatest.time._
+  implicit override val patienceConfig = PatienceConfig(timeout = Span(2, Minutes))
   implicit val connection = Neo4jREST(scala.util.Properties.envOrElse("NEO4J_SERVER", "localhost"))
 
   override def beforeEach() {
@@ -31,7 +33,7 @@ class CypherParserAsyncSpec extends FlatSpec with Matchers with BeforeAndAfterEa
       germany-[:speaks]->english,
       germany-[:speaks]->russian,
       (proptest {name:"proptest", tag:"anormcyphertest", f:1.234, i:1234, l:12345678910, s:"s", arri:[1,2,3,4], arrs:["a","b","c"], arrf:[1.234,2.345,3.456]});
-      """).async().futureValue
+      """).apply()
   }
 
   override def afterEach() {
@@ -40,7 +42,7 @@ class CypherParserAsyncSpec extends FlatSpec with Matchers with BeforeAndAfterEa
       where n.tag = "anormcyphertest"
       optional match (n)-[r]-()
       delete n, r;
-      """).async().futureValue
+      """).apply()
   }
 
   "CypherParser" should "be able to parse a node" in {

--- a/src/test/scala/org/anormcypher/async/Neo4jRESTTest.scala
+++ b/src/test/scala/org/anormcypher/async/Neo4jRESTTest.scala
@@ -8,30 +8,30 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
 class Neo4jRESTAsyncSpec extends FlatSpec with Matchers with BeforeAndAfterEach with ScalaFutures  {
-
+  import org.scalatest.time._
+  implicit override val patienceConfig = PatienceConfig(timeout = Span(2, Minutes))
   implicit val connection = Neo4jREST(scala.util.Properties.envOrElse("NEO4J_SERVER", "localhost"))
 
   override def beforeEach() {
-    val f = Cypher("""
+    Cypher("""
       CREATE (n {anormcyphername:'n'}),
       (n2 {anormcyphername:'n2'}),
       (n3 {anormcyphername:'n3'}),
       n-[:test {name:'r'}]->n2,
       n2-[:test {name:'r2'}]->n3;
-      """).async()
-    val f1 = Cypher("""
+      """).apply()
+    Cypher("""
       CREATE (n5 {anormcyphername:'n5'}), 
         (n6 {anormcyphername:'n6'}), 
         n5-[:test {name:'r', i:1, arr:[1,2,3], arrc:["a","b","c"]}]->n6;
-      """).async()
-    val f2 = Cypher("""
+      """).apply()
+    Cypher("""
       CREATE (n7 {anormcyphername:'nprops', i:1, arr:[1,2,3], arrc:['a','b','c']});
-      """).async()
-    Future.sequence(Seq(f,f1,f2)).futureValue
+      """).apply()
   }
 
   override def afterEach() {
-    Cypher("match (n) where has(n.anormcyphername) optional match (n)-[r]-() DELETE n,r;").async().futureValue
+    Cypher("match (n) where has(n.anormcyphername) optional match (n)-[r]-() DELETE n,r;").apply()
   }
 
   "Neo4jREST" should "be able to retrieve properties of nodes" in {

--- a/src/test/scala/org/anormcypher/async/Neo4jRESTTest.scala
+++ b/src/test/scala/org/anormcypher/async/Neo4jRESTTest.scala
@@ -1,0 +1,137 @@
+package org.anormcypher.async
+
+import org.anormcypher._
+import org.scalatest._
+import org.scalatest.concurrent.ScalaFutures
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+
+class Neo4jRESTAsyncSpec extends FlatSpec with Matchers with BeforeAndAfterEach with ScalaFutures  {
+
+  implicit val connection = Neo4jREST(scala.util.Properties.envOrElse("NEO4J_SERVER", "localhost"))
+
+  override def beforeEach() {
+    val f = Cypher("""
+      CREATE (n {anormcyphername:'n'}),
+      (n2 {anormcyphername:'n2'}),
+      (n3 {anormcyphername:'n3'}),
+      n-[:test {name:'r'}]->n2,
+      n2-[:test {name:'r2'}]->n3;
+      """).async()
+    val f1 = Cypher("""
+      CREATE (n5 {anormcyphername:'n5'}), 
+        (n6 {anormcyphername:'n6'}), 
+        n5-[:test {name:'r', i:1, arr:[1,2,3], arrc:["a","b","c"]}]->n6;
+      """).async()
+    val f2 = Cypher("""
+      CREATE (n7 {anormcyphername:'nprops', i:1, arr:[1,2,3], arrc:['a','b','c']});
+      """).async()
+    Future.sequence(Seq(f,f1,f2)).futureValue
+  }
+
+  override def afterEach() {
+    Cypher("match (n) where has(n.anormcyphername) optional match (n)-[r]-() DELETE n,r;").async().futureValue
+  }
+
+  "Neo4jREST" should "be able to retrieve properties of nodes" in {
+    val results = Cypher("START n=node(*) where n.anormcyphername = 'nprops' RETURN n;").async().futureValue
+    results.size should equal(1)
+    val node = results.map { row =>
+      row[NeoNode]("n")
+    }.head
+    node.props("anormcyphername") should equal("nprops")
+    node.props("i") should equal(1)
+    node.props("arr").asInstanceOf[Seq[Int]] should equal(Vector(1, 2, 3))
+    node.props("arrc").asInstanceOf[Seq[String]] should equal(Vector("a", "b", "c"))
+  }
+
+  it should "be able to retrieve collections of nodes" in {
+    val results = Cypher("""
+      START n=node(*)
+      where n.anormcyphername = 'n' or n.anormcyphername = 'n2'
+      RETURN collect(n);
+      """).async().futureValue
+    val nodes = results.map { row =>
+      row[Seq[NeoNode]]("collect(n)")
+    }.head
+    nodes.size should equal (2)
+  }
+
+  it should "be able to retrieve properties of relationships" in {
+    val results = Cypher("""
+      START n=node(*)
+      match n-[r]->m
+      where n.anormcyphername = 'n5'
+      RETURN r;
+      """).async().futureValue
+    results.size should equal (1)
+    val rel = results.map { row =>
+      row[NeoRelationship]("r")
+    }.head
+    rel.props("name") should equal ("r")
+    rel.props("i") should equal (1)
+    rel.props("arr").asInstanceOf[Seq[Int]] should equal (Vector(1,2,3))
+    rel.props("arrc").asInstanceOf[Seq[String]] should equal (Vector("a","b","c"))
+  }
+
+  it should "be able to retrieve collections of relationships" in {
+    val (r,r2) = Cypher("""
+      CREATE (n {anormcyphername:'n8'}), 
+        (n2 {anormcyphername:'n9'}), 
+        (n3 {anormcyphername:'n10'}), 
+        n-[r:test {name:'r'}]->n2, 
+        n2-[r2:test {name:'r2'}]->n3
+        return r, r2;
+      """).async().futureValue.map {
+      row => (row[NeoRelationship]("r"), row[NeoRelationship]("r2"))
+    }.head
+    val results = Cypher("""
+      START n=node(*) 
+      match p=(n)-[r*2]->(m)
+      where has(n.anormcyphername) 
+      and n.anormcyphername = "n8"
+      RETURN r;
+      """).async().futureValue
+    val rels = results.map { row =>
+      row[Seq[NeoRelationship]]("r")
+    }.head
+    rels.size should equal (2)
+    rels should contain (r)
+    rels should contain (r2)
+  }
+
+  it should "be able to retrieve non ascii characters" in {
+    val (nonAsciiCharacters, surrogatePair) = ("日本語", "\uD83D\uDE04")
+    Cypher("""CREATE (n {anormcyphername:'non-ascii-character', name:'%s', surrogate:'%s'});"""
+          .format(nonAsciiCharacters, surrogatePair)).async().futureValue
+    val results = Cypher(
+      """
+        START n=node(*)
+        WHERE n.anormcyphername = "non-ascii-character"
+        RETURN n;
+      """).async().futureValue
+    val node = results.map { row =>
+      row[NeoNode]("n")
+    }.head
+    node.props("name") should equal (nonAsciiCharacters)
+    node.props("surrogate") should equal (surrogatePair)
+  }
+
+  it should "be able to handle lists of maps in and out" in {
+    val lm = List(
+      Map("a" -> "b", "c" -> "d"), 
+      Map("a" -> "b", "c" -> "d"))
+    val q = Cypher("return {objects} as listOfMaps")
+      .on("objects" -> lm)
+    val res = q.async().futureValue.map(row =>
+      row[Seq[Map[String,String]]]("listOfMaps")
+    ).toList
+    res(0) should equal(lm)
+    val res2 = q.async().futureValue.map(row =>
+      row[Seq[Map[String,Any]]]("listOfMaps")
+    ).toList
+    res2(0) should equal(lm)
+  }
+
+}


### PR DESCRIPTION
Added asynchronous support to the cypher queries.

Where the apply method is usually used you can use async instead.

    Cypher(query)()

OR

    Cypher(query).apply()

VS

    Cypher(query).async()

Or any other method that executes the query you can append 'Async' to it to return a Future[T], e.g.

    Cypher(query).as(scalar[Long].single)

VS

    Cypher(query).asAsync(scalar[Long].single)