### PR TITLE
Fixes not working authentication.

### DIFF
--- a/src/main/scala/org/anormcypher/Neo4jREST.scala
+++ b/src/main/scala/org/anormcypher/Neo4jREST.scala
@@ -38,7 +38,7 @@ class Neo4jREST(wsclient: WSClient,
   def query(stmt: CypherStatement)(implicit ec: ExecutionContext): Enumerator[CypherResultRow] = {
     import play.api.http._
 
-    val req = wsclient.url(cypherUrl).withMethod(HttpVerbs.POST)
+    val req = request.withMethod(HttpVerbs.POST)
     val source = req.withBody(Json.toJson(stmt)(Neo4jREST.cypherStatementWrites)).stream()
     Enumerator.flatten(source map { case (header, body) => Neo4jStream.parse(body) })
   }


### PR DESCRIPTION
When i tried to use Neo4jREST with username and password, my local neo4j server returned "401 Unauthorized".
It seems Neo4jRREST's "request" method is responsible for that, but is not used in "query" method.
So I fixed "query" so that it uses "request".