### PR TITLE
feat(NeoNode): Add support for labels metadata on the NeoNode

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "AnormCypher"
  
-version := "0.7.1"
+version := "0.7.1.2"
  
 publishMavenStyle := true
 

--- a/src/main/main.iml
+++ b/src/main/main.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/scala" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="scala-sdk-2.11.7" level="application" />
+  </component>
+</module>

--- a/src/main/scala/org/anormcypher/Neo4jREST.scala
+++ b/src/main/scala/org/anormcypher/Neo4jREST.scala
@@ -149,7 +149,10 @@ object Neo4jREST {
 
   def asNode(msa: Map[String, Any]): MayErr[CypherRequestError, NeoNode] = (msa.get("self"), msa.get("data")) match {
     case (Some(IdURLExtractor(id)), Some(props: Map[_, _])) if props.keys.forall(_.isInstanceOf[String]) =>
-      Right(NeoNode(id, props.asInstanceOf[Map[String, Any]]))
+      Right(NeoNode(id, props.asInstanceOf[Map[String, Any]],
+        // add the labels metadata
+        msa.get("metadata").asInstanceOf[Some[Map[String,Any]]].get("labels").asInstanceOf[Seq[String]]
+      ))
     case x => Left(TypeDoesNotMatch("Unexpected type while building a Node"))
   }
 
@@ -164,6 +167,9 @@ object Neo4jREST {
 
 case class CypherRESTResult(columns: Vector[String], data: Seq[Seq[Any]])
 
-case class NeoNode(id: Long, props: Map[String, Any])
+case class NeoNode(id: Long, props: Map[String, Any], labels: Seq[String])
+object NeoNode {
+  def apply(id: Long, props: Map[String, Any]): NeoNode = NeoNode(id, props, Nil)
+}
 
 case class NeoRelationship(id: Long, props: Map[String, Any], start: Long, end: Long)

--- a/src/test/test.iml
+++ b/src/test/test.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/scala" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>


### PR DESCRIPTION
## Description
When retrieving a NeoNode from the database, add a `labels` function that provides the label metadata from the database.

For example, for the node `(foo:MyClass)`, the function `NeoNode.labels` will return `Seq[String]("MyClass")`