### PR TITLE
Upgrade to Play 2.5.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "AnormCypher"
  
-version := "0.9.0"
+version := "0.9.1-SNAPSHOT"
 
 publishMavenStyle := true
 
@@ -8,7 +8,7 @@ organization := "org.anormcypher"
 
 publishTo := Some(Resolver.sftp("AnormCypher repo", "repo.anormcypher.org", "/home/wfreeman/www/repo.anormcypher.org"))
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.11.8"
 
 scalacOptions ++= Seq("-encoding", "UTF-8", "-deprecation", "-unchecked", "-feature")
 
@@ -18,14 +18,14 @@ resolvers += "Bintray" at "http://dl.bintray.com/typesafe/maven-releases/com/typ
 
 parallelExecution in Test := false
 
-val playVersion = "2.4.3"
+val playVersion = "2.5.3"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+  "org.scalatest" %% "scalatest" % "2.2.6" % "test",
   "com.typesafe.play" %% "play-json" % playVersion,
   "com.typesafe.play" %% "play-ws" % playVersion,
   "com.typesafe.play" %% "play-iteratees" % playVersion,
-  "com.typesafe.play.extras" %% "iteratees-extras" % "1.5.0",
+  "com.typesafe.play.extras" %% "iteratees-extras" % "1.5.1-SNAPSHOT",
   "org.scala-lang.modules" %% "scala-async" % "0.9.2"
 )
 

--- a/src/test/scala/org/anormcypher/BaseAnormCypherSpec.scala
+++ b/src/test/scala/org/anormcypher/BaseAnormCypherSpec.scala
@@ -1,12 +1,18 @@
 package org.anormcypher
 
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
 import org.scalatest._
-import play.api.libs.ws._, ning._
+import play.api.libs.ws._
+import ning._
+
 import scala.concurrent._
 
 trait BaseAnormCypherSpec extends FlatSpec with Matchers with BeforeAndAfterEach with BeforeAndAfterAll {
+  implicit val system = ActorSystem("anormcypher")
+  implicit val materializer = ActorMaterializer()
   val wsclient = NingWSClient()
-  implicit val neo4jrest = Neo4jREST(scala.util.Properties.envOrElse("NEO4J_SERVER", "localhost"))(wsclient)
+  implicit val neo4jrest = Neo4jREST(scala.util.Properties.envOrElse("NEO4J_SERVER", "localhost"))(wsclient, materializer)
   implicit val ec = ExecutionContext.global
 
   val Tag = "anormcyphertest"


### PR DESCRIPTION
This is to upgrade anormcypher to use Play 2.5.3. I've changed the version to 0.9.1-SNAPSHOT and added a dependency to `iteratees-extras` 1.5.1-SNAPSHOT for which I submitted a pull request at https://github.com/jroper/play-iteratees-extras/pull/12
